### PR TITLE
Add field for whether or not to keep the destination on dispose

### DIFF
--- a/lib/src/udp/burt_socket.dart
+++ b/lib/src/udp/burt_socket.dart
@@ -55,6 +55,7 @@ abstract class BurtSocket extends UdpSocket {
     required this.device,
     super.destination,
     super.quiet,
+    super.keepDestination,
     this.collection,
   });
 

--- a/lib/src/udp/udp_socket.dart
+++ b/lib/src/udp/udp_socket.dart
@@ -49,9 +49,22 @@ class UdpSocket extends Service {
   /// is the default destination if those parameters are omitted.
   SocketInfo? destination;
 
+  /// Whether or not the default destination should be kept when the socket is dispose.
+  /// 
+  /// If this is true, [destination] will not be set to null when [dispose] is called.
+  /// 
+  /// This is intended to prevent scenarios where the socket automatically restarts due
+  /// to an allowed OS error (see [allowedErrors]), and the socket's destination can no
+  /// longer receive messages by this socket due to [destination] being set null.
+  final bool keepDestination;
+
   /// Opens a UDP socket on the given port that can send and receive data.
-  UdpSocket({required int? port, this.quiet = false, this.destination}) :
-    _port = port;
+  UdpSocket({
+    required int? port,
+    this.quiet = false,
+    this.destination,
+    this.keepDestination = false,
+  }) : _port = port;
 
   /// The UDP socket backed by `dart:io`.
   ///
@@ -103,7 +116,9 @@ class UdpSocket extends Service {
     if (!quiet) logger.info("Closing the socket on port $port");
     await _subscription?.cancel(); _subscription = null;
     _socket?.close(); _socket = null;
-    destination = null;
+    if (!keepDestination) {
+      destination = null;
+    }
   }
 
   /// Sends data to the given destination.

--- a/lib/src/udp/udp_socket.dart
+++ b/lib/src/udp/udp_socket.dart
@@ -50,12 +50,16 @@ class UdpSocket extends Service {
   SocketInfo? destination;
 
   /// Whether or not the default destination should be kept when the socket is dispose.
-  /// 
+  ///
   /// If this is true, [destination] will not be set to null when [dispose] is called.
-  /// 
+  ///
   /// This is intended to prevent scenarios where the socket automatically restarts due
   /// to an allowed OS error (see [allowedErrors]), and the socket's destination can no
   /// longer receive messages by this socket due to [destination] being set null.
+  ///
+  /// It only makes sense to use this when communicating with a static IP. If the destination port
+  /// can change between resets, using this may mean the socket will try to communicate with a port
+  /// that no longer exists. Practically, that means only the Dashboard should set this to be true.
   final bool keepDestination;
 
   /// Opens a UDP socket on the given port that can send and receive data.


### PR DESCRIPTION
Allows sockets with a static destination (like the dashboard sockets) to not be reset